### PR TITLE
add broadcasting to operators+-*/, and torch compare output of neuron x.matmul(w) + b case, passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 build
 
 # Prerequisites

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode
 build
 
 # Prerequisites

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "[python]": {
+        "python.formatting.provider": "black",
+        "python.formatting.blackArgs": ["--indent", "  "],
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2
+    },
+    "[cpp]": {
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
     "[cpp]": {
         "editor.insertSpaces": true,
         "editor.tabSize": 2
+    },
+    "files.associations": {
+        "vector": "cpp"
     }
 }

--- a/ATen/aten_neuron.cpp
+++ b/ATen/aten_neuron.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <ATen/ATen.h>
+#include <vector>
 
 int main() {
   std::vector<int> data1 = {1, 2, 3, 4, 5, 6};
@@ -14,6 +15,17 @@ int main() {
 
   std::cout << "NEURON" << std::endl;
   std::cout << result_aten << std::endl;
+
+  // Get the data out of result_aten and put it in a vector
+  std::vector<int> result_vector(result_aten.numel());
+  std::memcpy(result_vector.data(), result_aten.data_ptr<int>(), result_aten.numel() * sizeof(int));
+
+  // Print the result vector
+  std::cout << "Result vector:" << std::endl;
+  for (int value : result_vector) {
+    std::cout << value << " ";
+  }
+  std::cout << std::endl;
 
   return 0;
 }

--- a/ATen/aten_neuron.cpp
+++ b/ATen/aten_neuron.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+#include <ATen/ATen.h>
+
+int main() {
+  std::vector<int> data1 = {1, 2, 3, 4, 5, 6};
+  std::vector<int> data2 = {1, 2, 3, 4, 5, 6, 7, 8};
+
+  // create two tensors from the vectors
+  at::Tensor x_aten = at::from_blob(data1.data(), {3, 2}, at::kInt);
+  at::Tensor w_aten = at::from_blob(data2.data(), {2, 4}, at::kInt);
+  at::Tensor b_aten = at::tensor({1, 2, 3, 4}).unsqueeze(0);
+
+  at::Tensor result_aten = x_aten.matmul(w_aten) + b_aten;
+
+  std::cout << "NEURON" << std::endl;
+  std::cout << result_aten << std::endl;
+
+  return 0;
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(Tensor)
 
@@ -7,14 +6,20 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Enable AddressSanitizer
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+
+# Find the Torch package
+find_package(Torch REQUIRED)
+
 # Build googletest from the submodule
 add_subdirectory(googletest)
 
 # Add the target executable
 add_executable(${PROJECT_NAME} test.cpp)
 
-# Link the executable against the googletest library
-target_link_libraries(${PROJECT_NAME} gtest gtest_main)
+# Link the executable against the googletest and torch libraries
+target_link_libraries(${PROJECT_NAME} gtest gtest_main ${TORCH_LIBRARIES})
 
 # Add compiler flags
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -fsanitize=address)

--- a/GPT.md
+++ b/GPT.md
@@ -463,3 +463,35 @@ print(y_pred_test)
 ```
 
 In this example, we define the model weights w as a 2x1 tensor and the bias b as a 1-dimensional tensor. We define the single_layer_net function to perform a linear transformation of the input x using torch.matmul to compute the matrix multiplication of x and w, and adds the bias term b. We define the mse_loss function to compute the mean squared error loss between the predicted output and the target output. We define the learning rate lr and number of epochs num_epochs. We train the model using a for loop, where we perform a forward pass, compute the loss, perform a backward pass, and update the parameters using gradient descent. We print the loss every 100 epochs. Finally, we test the model on some new input data x_test and print the predicted output y_pred_test.
+
+# broadcasting in neuron activation bias
+
+In this code snippet, you are creating tensors using the PyTorch C++ API (LibTorch). The tensor b_aten represents a bias tensor, and it is added to the result of the matrix multiplication between x_aten and w_aten. Broadcasting is used here to perform the element-wise addition between tensors of different shapes.
+
+To explain how broadcasting works in this scenario, let's first understand the shapes of the tensors involved:
+
+x_aten: shape (3, 2)
+w_aten: shape (2, 4)
+b_aten: shape (1, 4) after unsqueezing
+The matrix multiplication (matmul) between x_aten and w_aten results in a tensor matmul_result of shape (3, 4). Now, you want to add the bias tensor b_aten to this result.
+
+Broadcasting rules in PyTorch (and NumPy) allow you to perform operations between tensors of different shapes as long as they are compatible. In this case, the tensors matmul_result (shape: (3, 4)) and b_aten (shape: (1, 4)) are compatible for broadcasting because their last dimensions match (4). When adding the bias tensor b_aten, broadcasting expands the tensor b_aten along the first dimension to match the shape of matmul_result, resulting in a tensor of shape (3, 4).
+
+The expanded b_aten will look like this:
+
+```
+[
+ [1, 2, 3, 4],
+ [1, 2, 3, 4],
+ [1, 2, 3, 4]
+]
+```
+Each row of the expanded b_aten will be added element-wise to the corresponding row of matmul_result. It is not adding the bias to every element in the weights of the neurons, but rather to the result of the matrix multiplication. This makes sense because the bias values are applied to the output of the matrix multiplication, not directly to the neuron weights. The addition of biases in this way allows for a shift in the activation function, enabling the neural network to better learn and represent complex patterns in the data.
+
+---
+
+Yes, that's correct. In this case, the weights of the neurons are represented as rows in the weight tensor w_aten. When you perform x_aten.matmul(w_aten), you are computing the dot product between each row in x_aten and each column in w_aten. The result of this operation will be a new tensor where each element (i, j) represents the dot product of the i-th row of x_aten and the j-th column of w_aten. This means that each row in the resulting tensor corresponds to the weighted sum of the input features for each neuron.
+
+When you add the bias tensor b_aten, the bias values are added element-wise to the result of the matrix multiplication, where each element in the bias tensor corresponds to a specific neuron. The broadcasting mechanism takes care of expanding the bias tensor to match the shape of the result, effectively adding the bias value to each neuron's output.
+
+So, in this scenario, the rows in w_aten represent the weights of the neurons, and the bias tensor b_aten is added to the output of the matrix multiplication to shift the activation function for each neuron.

--- a/junk.cpp
+++ b/junk.cpp
@@ -6,9 +6,17 @@ int main() {
   Tensor<int> x({3, 2}, {1, 2, 3, 4, 5, 6});
   Tensor<int> w({2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
   Tensor<int> b({1, 4}, {1, 2, 3, 4});
-  Tensor<int> result = x.matmul(w) + b;
-  // BUG broadcasting we need to broadcast O_O!!!
-  /*
+  // BUG broadcasting we need to broadcast O_O
+  //     broken because of + b!
+  // Does not work:
+  // Tensor<int> result = x.matmul(w) + b;
+  // Works:
+  Tensor<int> result = x.matmul(w);
+  std::cout << x << std::endl;
+  std::cout << w << std::endl;
+  std::cout << b << std::endl;
+  std::cout << result << std::endl;
+  /* this is without the + b
   [[1, 2],
   [3, 4],
   [5, 6]]
@@ -19,11 +27,20 @@ int main() {
   [23, 30, 37, 44],
   [35, 46, 57, 68]]
   */
-
-  Tensor<int> result = x.matmul(w) + b;
-  std::cout << x << std::endl;
-  std::cout << w << std::endl;
-  std::cout << b << std::endl;
-  std::cout << result << std::endl;
+  /*
+  >>> x = torch.tensor(((1, 2), (3, 4), (5, 6)))
+  >>> w = torch.tensor(((1, 2, 3, 4), (5, 6, 7, 8)))
+  >>> x
+  tensor([[1, 2],
+          [3, 4],
+          [5, 6]])
+  >>> w
+  tensor([[1, 2, 3, 4],
+          [5, 6, 7, 8]])
+  >>> x.matmul(w)
+  tensor([[11, 14, 17, 20],
+          [23, 30, 37, 44],
+          [35, 46, 57, 68]])
+  */
   auto result_v = result.storage()->data();
 }

--- a/junk.cpp
+++ b/junk.cpp
@@ -1,0 +1,29 @@
+#include "tensor.h"
+#include <vector>
+#include <iostream>
+
+int main() {
+  Tensor<int> x({3, 2}, {1, 2, 3, 4, 5, 6});
+  Tensor<int> w({2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
+  Tensor<int> b({1, 4}, {1, 2, 3, 4});
+  Tensor<int> result = x.matmul(w) + b;
+  // BUG broadcasting we need to broadcast O_O!!!
+  /*
+  [[1, 2],
+  [3, 4],
+  [5, 6]]
+  [[1, 2, 3, 4],
+  [5, 6, 7, 8]]
+  [[1, 2, 3, 4]]
+  [[11, 14, 17, 20],
+  [23, 30, 37, 44],
+  [35, 46, 57, 68]]
+  */
+
+  Tensor<int> result = x.matmul(w) + b;
+  std::cout << x << std::endl;
+  std::cout << w << std::endl;
+  std::cout << b << std::endl;
+  std::cout << result << std::endl;
+  auto result_v = result.storage()->data();
+}

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,7 @@
 rm -rf build
 mkdir -p build
 cd build
+cmake -DCMAKE_PREFIX_PATH=$(python -c 'import torch;print(torch.utils.cmake_prefix_path)') ..
 cmake ..
 make
 ./Tensor

--- a/tensor.h
+++ b/tensor.h
@@ -162,8 +162,11 @@ class Tensor {
     return applyElementwise(scalar, std::divides<T>());
   }
 
-  // TODO(yrom1) support broadcasting during matmul
   Tensor<T> matmul(const Tensor<T> &other) const {
+    // https://pytorch.org/docs/stable/generated/torch.matmul.html
+    // This is supported:
+    // If both arguments are 2-dimensional, the matrix-matrix product is returned.
+    // Everything else is not supported yet.
     if (sizes_.size() != 2 || other.sizes_.size() != 2) {
       throw std::runtime_error("Both tensors must be 2-dimensional.");
     }

--- a/test.cpp
+++ b/test.cpp
@@ -143,51 +143,25 @@ TEST(TensorTest, CreateAndPrintTensorRepr) {
 
 TEST(Torch, Neuron) {
   // Test input tensors
-  Tensor<float> x({3, 2}, {1, 2, 3, 4, 5, 6});
-  Tensor<float> w({2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
-  Tensor<float> b({1, 4}, {1, 2, 3, 4});
+  Tensor<int> x({3, 2}, {1, 2, 3, 4, 5, 6});
+  Tensor<int> w({2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
+  Tensor<int> b({1, 4}, {1, 2, 3, 4});
+  Tensor<int> result = x.matmul(w) + b;
+  auto result_v = result.storage()->data();
 
-  // Perform operation with custom Tensor class
-  Tensor<float> result = x.matmul(w) + b;
-
-  // Perform operation with ATen
-  // at::Tensor x_aten = at::tensor({{1, 2}, {3, 4}, {5, 6}}, at::dtype(at::kFloat));
-  // at::Tensor w_aten = at::tensor({{1, 2, 3, 4}, {5, 6, 7, 8}}, at::dtype(at::kFloat));
-  std::vector<std::vector<float>> x_data = {{1, 2}, {3, 4}, {5, 6}};
-  std::vector<float> x_flat;
-
-  // Flatten the x_data vector
-  for (const auto &row : x_data) {
-    x_flat.insert(x_flat.end(), row.begin(), row.end());
-  }
-
-  // Create a 2D float tensor from the flattened data
-  at::Tensor x_aten = at::from_blob(x_flat.data(), {3, 2}, at::kFloat);
-
-  // Create a vector of vector of floats
-  std::vector<std::vector<float>> w_data = {{1, 2, 3, 4}, {5, 6, 7, 8}};
-  std::vector<float> w_flat;
-
-  // Flatten the w_data vector
-  for (const auto &row : w_data) {
-    w_flat.insert(w_flat.end(), row.begin(), row.end());
-  }
-  at::Tensor w_aten = at::from_blob(w_flat.data(), {2, 4}, at::kFloat);
-  // for some reason this might work
-
-
+  std::vector<int> data1 = {1, 2, 3, 4, 5, 6};
+  std::vector<int> data2 = {1, 2, 3, 4, 5, 6, 7, 8};
+  at::Tensor x_aten = at::from_blob(data1.data(), {3, 2}, at::kInt);
+  at::Tensor w_aten = at::from_blob(data2.data(), {2, 4}, at::kInt);
   at::Tensor b_aten = at::tensor({1, 2, 3, 4}).unsqueeze(0);
-
   at::Tensor result_aten = x_aten.matmul(w_aten) + b_aten;
+  std::vector<int> result_aten_v(result_aten.numel());
+  std::memcpy(result_aten_v.data(), result_aten.data_ptr<int>(), result_aten.numel() * sizeof(int));
 
-  // Compare results
-  ASSERT_TRUE(result_aten.is_contiguous());
-  auto result_data = result.storage()->data();
-  auto result_aten_data = result_aten.data_ptr<float>();
+  std::cout << result_v << std::endl;
+  std::cout << result_aten_v << std::endl;
 
-  for (size_t i = 0; i < result_data.size(); ++i) {
-    ASSERT_FLOAT_EQ(result_data[i], result_aten_data[i]);
-  }
+  EXPECT_EQ(result_v, result_aten_v);
 }
 
 

--- a/test.cpp
+++ b/test.cpp
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include <torch/torch.h>
+
 #include "gtest/gtest.h"
 #include "tensor.h"  // NOLINT (build/include_subdir)
 
@@ -137,6 +139,58 @@ TEST(TensorTest, CreateAndPrintTensorRepr) {
 //   Tensor<int> submatrix_slice = t.slice({0, 1}, {2, 2});
 //   EXPECT_EQ(submatrix_slice.repr(), "Tensor({2, 2}, {2, 3, 5, 6})");
 // }
+
+
+TEST(Torch, Neuron) {
+  // Test input tensors
+  Tensor<float> x({3, 2}, {1, 2, 3, 4, 5, 6});
+  Tensor<float> w({2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
+  Tensor<float> b({1, 4}, {1, 2, 3, 4});
+
+  // Perform operation with custom Tensor class
+  Tensor<float> result = x.matmul(w) + b;
+
+  // Perform operation with ATen
+  // at::Tensor x_aten = at::tensor({{1, 2}, {3, 4}, {5, 6}}, at::dtype(at::kFloat));
+  // at::Tensor w_aten = at::tensor({{1, 2, 3, 4}, {5, 6, 7, 8}}, at::dtype(at::kFloat));
+  std::vector<std::vector<float>> x_data = {{1, 2}, {3, 4}, {5, 6}};
+  std::vector<float> x_flat;
+
+  // Flatten the x_data vector
+  for (const auto &row : x_data) {
+    x_flat.insert(x_flat.end(), row.begin(), row.end());
+  }
+
+  // Create a 2D float tensor from the flattened data
+  at::Tensor x_aten = at::from_blob(x_flat.data(), {3, 2}, at::kFloat);
+
+  // Create a vector of vector of floats
+  std::vector<std::vector<float>> w_data = {{1, 2, 3, 4}, {5, 6, 7, 8}};
+  std::vector<float> w_flat;
+
+  // Flatten the w_data vector
+  for (const auto &row : w_data) {
+    w_flat.insert(w_flat.end(), row.begin(), row.end());
+  }
+  at::Tensor w_aten = at::from_blob(w_flat.data(), {2, 4}, at::kFloat);
+  // for some reason this might work
+
+
+  at::Tensor b_aten = at::tensor({1, 2, 3, 4}).unsqueeze(0);
+
+  at::Tensor result_aten = x_aten.matmul(w_aten) + b_aten;
+
+  // Compare results
+  ASSERT_TRUE(result_aten.is_contiguous());
+  auto result_data = result.storage()->data();
+  auto result_aten_data = result_aten.data_ptr<float>();
+
+  for (size_t i = 0; i < result_data.size(); ++i) {
+    ASSERT_FLOAT_EQ(result_data[i], result_aten_data[i]);
+  }
+}
+
+
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- tests fail but at least it compiles ...
- aten matmul + b example
- get neuron data into vector
- wip neruon test, getting gtest error cannot compare the results (need to check if Tensor<int> working correctly to get vector data)
- add vscode for two space c++ tab
- dont ignore vscode in gitignore
- Revert "dont ignore vscode in gitignore"
- found broadcasting issue
- matmul is working but give more detail on the + b error
- GPT conversation about broadcasting neuron bias
- holy molly it did broadcasting
